### PR TITLE
config file support for sources and other configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ After a few moments, Mantl API should be running on your cluster.
  `listen`                 | :4001                                                                     | Listen for connections at this address
  `zookeeper`              | Discovered via a `marathon` service registered in Consul                  | Comma-delimited list of zookeeper servers
  `force-sync`             | False                                                                     | Forces a synchronization of all repository sources at startup
+ `config-file`            | None                                                                      | Specifies an optional configuration file
 
-Every option can be set via environment variables prefixed with `MANTL_API`. For example, you can use `MANTL_API_LOG_LEVEL` for `log-level`, `MANTL_API_CONSUL` for `consul`, and so on.
+Every option can be set via environment variables prefixed with `MANTL_API`. For example, you can use `MANTL_API_LOG_LEVEL` for `log-level`, `MANTL_API_CONSUL` for `consul`, and so on. You can also specify all configuration from a [TOML](https://github.com/toml-lang/toml) configuration file using the `config-file` argument.
 
 ## Package Repository
 
@@ -128,6 +129,30 @@ The package repositories are synchronized to the Consul K/V backend. If you want
 ```shell
 mantl-api sync --consul http://consul.service.consul:8500
 ```
+
+### Configuring Sources
+
+If you want to use different source repositories, you can specify a configuration file that contains your source definitions using the `--config-file` argument. Here is an example configuration file that uses 2 sources &mdash; one named "mesosphere" from a git repository and the other named "mantl-universe" from the local file system:
+
+```toml
+[sources]
+
+[sources.mesosphere]
+path = "https://github.com/mesosphere/universe.git"
+type = "git"
+index = 0
+
+[sources.mantl]
+path = "/home/ryan/Projects/mantl-universe"
+index = 1
+```
+
+The following attributes can be specified for each source:
+
+* path
+* type &mdash; git or filesystem (default)
+* index
+* branch &mdash; only applicable for the *git* type
 
 ## Usage
 

--- a/install/source.go
+++ b/install/source.go
@@ -28,6 +28,10 @@ type Source struct {
 	Index      int
 }
 
+func (s Source) IsValid() bool {
+	return (s.Name != "" && s.Path != "")
+}
+
 func (install *Install) syncSource(source *Source) error {
 	switch source.SourceType {
 	case FileSystem:

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 const Name = "mantl-api"
-const Version = "0.1.3-pre"
+const Version = "0.1.3"
 
 func main() {
 	rootCmd := &cobra.Command{

--- a/main.go
+++ b/main.go
@@ -226,7 +226,7 @@ func readConfigFile() {
 	if configFile != "" {
 		if _, err := os.Stat(configFile); err == nil {
 			viper.SetConfigFile(configFile)
-			viper.ReadInConfig()
+			err = viper.ReadInConfig()
 			if err != nil {
 				log.Warnf("Could not read configuration file: %v", err)
 			}

--- a/main.go
+++ b/main.go
@@ -12,11 +12,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
+	"os"
 	"strings"
 )
 
 const Name = "mantl-api"
-const Version = "0.1.2"
+const Version = "0.1.3-pre"
 
 func main() {
 	rootCmd := &cobra.Command{
@@ -26,6 +27,7 @@ func main() {
 			start()
 		},
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			readConfigFile()
 			setupLogging()
 		},
 	}
@@ -44,6 +46,7 @@ func main() {
 	rootCmd.PersistentFlags().String("listen", ":4001", "mantl-api listen address")
 	rootCmd.PersistentFlags().String("zookeeper", "", "Comma-delimited list of zookeeper servers")
 	rootCmd.PersistentFlags().Bool("force-sync", false, "Force a synchronization of all sources")
+	rootCmd.PersistentFlags().String("config-file", "", "The path to a configuration file")
 
 	for _, flags := range []*pflag.FlagSet{rootCmd.PersistentFlags()} {
 		err := viper.BindPFlags(flags)
@@ -160,7 +163,7 @@ func sync(inst *install.Install, force bool) {
 		}
 	}
 
-	sources := []*install.Source{
+	defaultSources := []*install.Source{
 		&install.Source{
 			Name:       "mantl",
 			Path:       "https://github.com/CiscoCloud/mantl-universe.git",
@@ -175,7 +178,62 @@ func sync(inst *install.Install, force bool) {
 		},
 	}
 
+	sources := []*install.Source{}
+
+	configuredSources := viper.GetStringMap("sources")
+
+	if len(configuredSources) > 0 {
+		for name, val := range configuredSources {
+			source := &install.Source{Name: name, SourceType: install.FileSystem}
+			sourceConfig := val.(map[string]interface{})
+
+			if path, ok := sourceConfig["path"].(string); ok {
+				source.Path = path
+			}
+
+			if index, ok := sourceConfig["index"].(int64); ok {
+				source.Index = int(index)
+			}
+
+			if sourceType, ok := sourceConfig["type"].(string); ok {
+				if strings.EqualFold(sourceType, "git") {
+					source.SourceType = install.Git
+				}
+			}
+
+			if branch, ok := sourceConfig["branch"].(string); ok {
+				source.Branch = branch
+			}
+
+			if source.IsValid() {
+				sources = append(sources, source)
+			} else {
+				log.Warnf("Invalid source configuration for %s", name)
+			}
+		}
+	}
+
+	if len(sources) == 0 {
+		sources = defaultSources
+	}
+
 	inst.SyncSources(sources, force)
+}
+
+func readConfigFile() {
+	// read configuration file if specified
+	configFile := viper.GetString("config-file")
+	if configFile != "" {
+		if _, err := os.Stat(configFile); err == nil {
+			viper.SetConfigFile(configFile)
+			viper.ReadInConfig()
+			if err != nil {
+				log.Warnf("Could not read configuration file: %v", err)
+			}
+		} else {
+			log.Warnf("Could not find configuration file: %s", configFile)
+		}
+	}
 }
 
 func setupLogging() {


### PR DESCRIPTION
This enables the ability to specify a configuration file via the `--config-file` option. All command line options should be configurable + there is now the ability to configure sources:

``` toml
consul = "https://192.168.242.55:8500"

[sources]

[sources.mantl]
path = "/Users/ryan/Projects/mantl-universe"
index = 1

[sources.mesosphere]
path = "https://github.com/mesosphere/universe.git"
type = "git"
index = 0
```

The above example configuration specifies a consul url as well as two repository sources. One from git and the other from the local file system.
