### PR TITLE
updated zookeeper discovery and config

### DIFF
--- a/install/transformers.go
+++ b/install/transformers.go
@@ -1,0 +1,45 @@
+package install
+
+import (
+	"fmt"
+	"strings"
+)
+
+type valueTransformer func(interface{}, packageDefinition) string
+
+func zookeeperHosts(v interface{}, d packageDefinition) string {
+	zkVal := "zookeeper.service.consul:2181"
+	strval := v.(string)
+	if zkHosts, ok := getConfigVal(d.apiConfig, "mantl", "zookeeper", "hosts").(string); ok {
+		if strings.Contains(strval, zkVal) {
+			strval = strings.Replace(strval, zkVal, zkHosts, -1)
+		}
+	}
+	return strval
+}
+
+func intTransformer(v interface{}, d packageDefinition) string {
+	if strval, ok := v.(string); ok { // already been converted
+		return strval
+	}
+	return fmt.Sprintf("%d", int(v.(float64)))
+}
+
+func numberTransformer(v interface{}, d packageDefinition) string {
+	if strval, ok := v.(string); ok { // already been converted
+		return strval
+	}
+	return fmt.Sprintf("%0.2f", v.(float64))
+}
+
+var valueTransformers = map[string][]valueTransformer{
+	"string": []valueTransformer{
+		zookeeperHosts,
+	},
+	"integer": []valueTransformer{
+		intTransformer,
+	},
+	"number": []valueTransformer{
+		numberTransformer,
+	},
+}

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 const Name = "mantl-api"
-const Version = "0.1.9"
+const Version = "0.2.0"
 
 var wg sync.WaitGroup
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/CiscoCloud/mantl-api/marathon"
 	"github.com/CiscoCloud/mantl-api/mesos"
 	"github.com/CiscoCloud/mantl-api/utils/http"
-	"github.com/CiscoCloud/mantl-api/zookeeper"
 	log "github.com/Sirupsen/logrus"
 	consul "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-cleanhttp"
@@ -144,9 +143,8 @@ func start() {
 	} else {
 		zkHosts = strings.Split(zkUrls, ",")
 	}
-	zk := zookeeper.NewZookeeper(zkHosts)
 
-	inst, err := install.NewInstall(client, marathonClient, mesosClient, zk)
+	inst, err := install.NewInstall(client, marathonClient, mesosClient, zkHosts)
 	if err != nil {
 		log.Fatalf("Could not create install client: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -98,7 +98,12 @@ func start() {
 
 	marathonUrl := viper.GetString("marathon")
 	if marathonUrl == "" {
-		marathonUrl = NewDiscovery(client, "marathon", "", "http", "http://localhost:8080").discoveredUrl
+		marathonHosts := NewDiscovery(client, "marathon", "").discoveredHosts
+		if len(marathonHosts) > 0 {
+			marathonUrl = fmt.Sprintf("http://%s", marathonHosts[0])
+		} else {
+			marathonUrl = "http://localhost:8080"
+		}
 	}
 	marathonClient, err := marathon.NewMarathon(
 		marathonUrl,
@@ -112,7 +117,12 @@ func start() {
 
 	mesosUrl := viper.GetString("mesos")
 	if mesosUrl == "" {
-		mesosUrl = NewDiscovery(client, "mesos", "leader", "http", "http://localhost:5050").discoveredUrl
+		mesosHosts := NewDiscovery(client, "mesos", "leader").discoveredHosts
+		if len(mesosHosts) > 0 {
+			mesosUrl = fmt.Sprintf("http://%s", mesosHosts[0])
+		} else {
+			mesosUrl = "http://locahost:5050"
+		}
 	}
 	mesosClient, err := mesos.NewMesos(
 		mesosUrl,
@@ -124,12 +134,17 @@ func start() {
 		log.Fatalf("Could not create mesos client: %v", err)
 	}
 
+	var zkHosts []string
 	zkUrls := viper.GetString("zookeeper")
 	if zkUrls == "" {
-		zkUrls = NewDiscovery(client, "zookeeper", "", "", "localhost:2181").discoveredUrl
+		zkHosts = NewDiscovery(client, "zookeeper", "").discoveredHosts
+		if len(zkHosts) == 0 {
+			zkHosts = []string{"locahost:2181"}
+		}
+	} else {
+		zkHosts = strings.Split(zkUrls, ",")
 	}
-	zkServers := strings.Split(zkUrls, ",")
-	zk := zookeeper.NewZookeeper(zkServers)
+	zk := zookeeper.NewZookeeper(zkHosts)
 
 	inst, err := install.NewInstall(client, marathonClient, mesosClient, zk)
 	if err != nil {


### PR DESCRIPTION
- in packages, can now use `mantl.zookeeper.hosts` to get a comma-delimited list of zk hosts and ports for use in zk connections. It is no longer recommended to use zookeeper.service.consul
- will replace zookeeper.service.consul in templates with discovered zk hosts for backwards compatibility
